### PR TITLE
chore(deps): update default registry's baseline to `ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+    "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0`.