### PR TITLE
chore(deps): update default registry's baseline to `dd3097e305afa53f7b4312371f62058d2e665320`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+    "baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `dd3097e305afa53f7b4312371f62058d2e665320`.